### PR TITLE
check for message in the error body

### DIFF
--- a/lib/Buffer/HttpClient/ErrorHandler.php
+++ b/lib/Buffer/HttpClient/ErrorHandler.php
@@ -37,6 +37,8 @@ class ErrorHandler
             if ($response->isContentType('json') && is_array($body)) {
                 if (isset($body['error'])) {
                     $message = $body['error'];
+                } else if (isset($body['message'])) {
+                    $message = $body['message'];
                 } else {
                     $message = 'Unable to select error message from json returned by request responsible for error';
                 }


### PR DESCRIPTION
We kept receiving the error: "Unable to select error message from json returned by request responsible for error" when really we didn't need to. 

I did some digging and found that buffer sometimes gives back a message variable instead of body so this gives better error reporting.